### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   </div>
   <a href='https://arxiv.org/abs/2510.08431'><img src='https://img.shields.io/badge/Paper%20(arXiv)-2510.08431-red?logo=arxiv'></a>  &nbsp;
   <a href='https://research.nvidia.com/labs/dir/rcm'><img src='https://img.shields.io/badge/Website-green?logo=homepage&logoColor=white'></a> &nbsp;
+  <a href="https://deepwiki.com/NVlabs/rcm"><img src="https://deepwiki.com/badge.svg" alt="DeepWiki"></a>
 </div>
 
 ## Overview


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/NVlabs/rcm) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.